### PR TITLE
Save performance when unnecessary

### DIFF
--- a/release/tsukino-mito.base.css
+++ b/release/tsukino-mito.base.css
@@ -155,8 +155,10 @@
 /* Background */
 div#app-mount.appMount-2yBXZl {
     background-image: linear-gradient(270deg, #4BB4E0, #DD9FBD 60%);
-    animation: Gradient 4s ease infinite;
     background-size: 200% 100%;
+}
+.app-focused.full-motion div#app-mount.appMount-2yBXZl {
+    animation: Gradient 4s ease infinite;
 }
 @keyframes Gradient {
     0% {


### PR DESCRIPTION
When Discord is unfocused or is in reduced motion, the background animation automatically stops to save performance and reduce lags.